### PR TITLE
Incompatibility with `Xtext v2.33.0` and `MWE2 v2.16.0`: Fixes broken dependencies

### DIFF
--- a/org.emoflon.delta/build.properties
+++ b/org.emoflon.delta/build.properties
@@ -16,5 +16,4 @@ bin.includes = META-INF/,\
                gen/,\
                plugin.properties
 source..=src/,gen/
-additional.bundles = org.eclipse.xtext.xbase,\
-                     org.eclipse.xtext.generator
+additional.bundles = org.eclipse.xtext.xbase


### PR DESCRIPTION
This PR helps towards closing https://github.com/eMoflon/emoflon-ibex/issues/420.